### PR TITLE
"0" とか "" が undef になってしまわないようにする

### DIFF
--- a/lib/Unicode/Normalize/Mac.pm
+++ b/lib/Unicode/Normalize/Mac.pm
@@ -10,14 +10,14 @@ my $decompose = qr/([^\x{2000}-\x{2FFF}\x{F900}-\x{FAFF}\x{2F800}-\x{2FAFF}]*)/;
 
 sub NFC_mac {
     my ($unicode) = @_;
-    return unless $unicode;
+    return unless defined $unicode;
     $unicode =~ s/$decompose/Unicode::Normalize::NFC($1)/eg;
     $unicode;
 }
 
 sub NFD_mac {
     my ($unicode) = @_;
-    return unless $unicode;
+    return unless defined $unicode;
     $unicode =~ s/$decompose/Unicode::Normalize::NFD($1)/eg;
     $unicode;
 }

--- a/t/02_normalize.t
+++ b/t/02_normalize.t
@@ -10,6 +10,8 @@ my %map = (
     "\x{00E9}" => "\x{0065}\x{0301}", # LATIN SMALL LETTER E WITH ACUTE
     "\x{3060}" => "\x{305F}\x{3099}", # HIRAGANA LETTER DA
     "\x{FA1B}" => "\x{FA1B}",         # Chinese Kanji FUKU(lucky) / NFD() => U+798F
+    "0"        => "0",                # 0
+    ""         => "",                 # zero-length value
 );
 
 while (my ($c, $d) = each %map) {


### PR DESCRIPTION
Encode::UTF8Mac を使ってる時に decode('utf-8-mac', '0') すると undef が帰ってきてしまうので、unless の拡大解釈を避けるようにしました。
